### PR TITLE
Add stub call in decode_opc() and stub in measure.c

### DIFF
--- a/target/riscv/measure.c
+++ b/target/riscv/measure.c
@@ -17,3 +17,10 @@
  * You should have received a copy of the GNU General Public License along with
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
+#include <stdio.h>
+#include "measure.h"
+
+void riscv_measure_stub(uint32_t opc) {
+    printf("# Primary opcode: 0x%02x\n", opc);
+}

--- a/target/riscv/measure.h
+++ b/target/riscv/measure.h
@@ -1,0 +1,9 @@
+
+#ifndef RISCV_MEASURE_H
+#define RISCV_MEASURE_H
+
+#include <stdint.h>
+
+void riscv_measure_stub(uint32_t opc);
+
+#endif /* RISCV_MEASURE_H */

--- a/target/riscv/meson.build
+++ b/target/riscv/meson.build
@@ -19,6 +19,7 @@ riscv_ss.add(files(
   'vector_internals.c',
   'bitmanip_helper.c',
   'translate.c',
+  'measure.c',
   'm128_helper.c',
   'crypto_helper.c',
   'zce_helper.c',

--- a/target/riscv/translate.c
+++ b/target/riscv/translate.c
@@ -19,6 +19,7 @@
 #include "qemu/osdep.h"
 #include "qemu/log.h"
 #include "cpu.h"
+#include "measure.h"
 #include "tcg/tcg-op.h"
 #include "exec/helper-proto.h"
 #include "exec/helper-gen.h"
@@ -1262,6 +1263,10 @@ static void decode_opc(CPURISCVState *env, DisasContext *ctx)
                                                ctx->base.pc_next + 2));
         }
         ctx->opcode = opcode;
+
+	/* Insert stub call */
+	uint32_t primary = ctx->opcode & 0x7f;
+	riscv_measure_stub(primary);
 
         for (guint i = 0; i < ctx->decoders->len; ++i) {
             riscv_cpu_decode_fn func = g_ptr_array_index(ctx->decoders, i);


### PR DESCRIPTION
Changes included:

1. Added a call to `riscv_measure_stub()` inside `decode_opc()` in target/riscv/translate.c.
2. Implemented the stub function in target/riscv/measure.c.
3. Created a header target/riscv/measure.h declaring the stub.
4. Modified target/riscv/meson.build to include measure.c in the build.